### PR TITLE
Add link to Adopt AI platform in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AdoptXchange
-Methods and examples to connect external agents to interact with agents built on the AdoptAI platform.
+Methods and examples to connect external agents to interact with agents built on the [Adopt AI platform](https://www.adopt.ai).
 
 ## Environment Setup
 


### PR DESCRIPTION
## Summary
Added a link to the Adopt AI platform (https://www.adopt.ai) in the README.md file.

## Changes
- Updated the description line to link "Adopt AI platform" text to https://www.adopt.ai
- Improves navigation and provides direct access to the platform for users

## Type of Change
- [x] Documentation update